### PR TITLE
added syntax hide

### DIFF
--- a/minecraft-mcfunctions/syntaxes/minecraft-mcfunction.tmLanguage.json
+++ b/minecraft-mcfunctions/syntaxes/minecraft-mcfunction.tmLanguage.json
@@ -198,6 +198,7 @@
         { "name": "entity.name.type.class.function", "match": "\\bfunction\\b" },
         { "name": "entity.name.type.class.gamemode", "match": "\\bgamemode\\b" },
         { "name": "entity.name.type.class.gamerule", "match": "\\bgamerule\\b" },
+        { "name": "entity.name.type.class.hide", "match": "\\bhide\\b" },
         { "name": "entity.name.type.class.give", "match": "\\bgive\\b" },
         { "name": "entity.name.type.class.kill", "match": "\\bkill\\b" },
         { "name": "entity.name.type.class.list", "match": "\\blist\\b" },


### PR DESCRIPTION
"hide" isn't a command but is a syntax to remove the current function from the auto complete. When typing /function it would hide that function from the list if the string hide was present in that function. I keep getting errors for this when I use it in vs code, so I thought I would make a commit.

Here is what I mean
![image](https://user-images.githubusercontent.com/61999256/108118313-2b4a4a80-706c-11eb-86eb-69b589fd6466.png)
![image](https://user-images.githubusercontent.com/61999256/108118368-42893800-706c-11eb-9bba-49e18df4107a.png)


