### PR TITLE
Add `.item.json` as a valid extension for behavior pack item

### DIFF
--- a/package.json
+++ b/package.json
@@ -948,7 +948,7 @@
           "*Behavior*Pack*/items/**/*.{json,jsonc,json5}",
           "*BP*/items/**/*.{json,jsonc,json5}",
           "*bp*/items/**/*.{json,jsonc,json5}",
-          "*.{item.bp,i.bp,bpi,bp_item}.{json,jsonc,json5}"
+          "*.{item,item.bp,i.bp,bpi,bp_item}.{json,jsonc,json5}"
         ],
         "url": "./minecraft-bedrock-schemas/behavior/items/items.json"
       },


### PR DESCRIPTION
Since the current way of implementing items don't use the `.rp_item` anymore, maybe it's worth to assume that things that use the `.item.json` extension refer to the behavior pack items.