### PR TITLE
fix: ensure property is safely accessed in getJsonPath function

### DIFF
--- a/server/src/lib/lsp/completion/service.ts
+++ b/server/src/lib/lsp/completion/service.ts
@@ -83,8 +83,9 @@ export class CompletionService extends BaseService implements Partial<IService> 
       };
     } catch (err: any) {
       const code = ErrorCodes.CompletionService + (err.code ?? 0);
-
-      return new ResponseError<void>(code, `error on ${filename}, error: ` + JSON.stringify(err, undefined, 2));
+      
+      // Somehow just stringifying the error returns an empty object, so I make sure message and stack are always there
+      return new ResponseError<void>(code, `error on ${filename}, error: ` + JSON.stringify({...err, message: err.message, stack: err.stack}, undefined, 2));
     } finally {
       this.logger.debug(`exiting on: ${filename}`);
       workDoneProgress.done();

--- a/server/src/lib/minecraft/json/path.ts
+++ b/server/src/lib/minecraft/json/path.ts
@@ -15,7 +15,7 @@ export function getJsonPath(cursor: number, text: string | TextDocument): Path {
   const pos = jsonc.getLocation(text, cursor);
 
   return {
-    property: pos.path[pos.path.length - 1].toString(),
+    property: (pos.path[pos.path.length - 1] ?? '').toString(),
     path: pos.path.join("/"),
     isProperty: !pos.isAtPropertyKey,
   };


### PR DESCRIPTION
When trying to trigger completion in an empty JSON file I always get an error. This PR fixes error reporting (which was always `{}` in this case) and fixes the actual error, that was triggered (`toString` called on undefined in `getJsonPath`)